### PR TITLE
Adding support for indexing Cardano

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,12 @@ signal-hook = "0.3.17"
 ouroboros = "0.18.4"
 derive_more = "0.99.18"
 proptest = "1.5.0"
+ergo-lib = "0.27.1"
+reqwest = { version = "0.12.5", default-features = false, features = [
+    "json",
+    "blocking",
+] }
+serde_json = "1.0.122"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,14 @@ signal-hook = "0.3.17"
 ouroboros = "0.18.4"
 derive_more = "0.99.18"
 proptest = "1.5.0"
-ergo-lib = "0.27.1"
+# ergo-lib = "0.27.1"
 reqwest = { version = "0.12.5", default-features = false, features = [
     "json",
     "blocking",
 ] }
 serde_json = "1.0.122"
 async-trait = "0.1.81"
+pallas = "0.29.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "blocking",
 ] }
 serde_json = "1.0.122"
+async-trait = "0.1.81"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## DB schema
 
+Indexer uses block/tx/box indexes over hashes which allows for much better space efficiency and for ~ 10 000 txs/s speed for BTC and 8 000 txs/s 
+for chains with assets like Cardano/Ergo. Chain tip is eventually consistent due to using indexes over hashes, ie. forks get settled eventually.
+
 ```
 PK           = unique pointer to an object
 BirthPK      = unique pointer to an object of creation
@@ -15,6 +18,8 @@ UtxoBirthPk  = block_height|tx_index|utxo_index
 AssetPk      = block_height|tx_index|utxo_index|asset_index
 AssetBirthPk = block_height|tx_index|utxo_index|asset_index
 ```
+
+**Meta column family** keeps track 
 
 **UtxoIndexes** and **AssetIndex** are seconary indexes that keep entity (`asset-id/address/script_hash`) under small-size `UtxoBirthPk/AssetBirthPk`
 and references/relations to all further occurences to them.

--- a/benches/btc_processor_benchmark.rs
+++ b/benches/btc_processor_benchmark.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use ci::{
-    api::{BlockProcessor, BlockchainClient},
+    api::BlockProcessor,
     eutxo::btc::{btc_client::BtcClient, btc_processor::BtcProcessor},
     info,
     model::Block,

--- a/benches/indexer_benchmark.rs
+++ b/benches/indexer_benchmark.rs
@@ -1,7 +1,7 @@
 use std::{fs, sync::Arc, time::Duration};
 
 use ci::{
-    api::{BlockProcessor, BlockProvider, BlockchainClient, Storage},
+    api::{BlockProcessor, BlockProvider, Storage},
     block_service::BlockService,
     eutxo::{
         btc::{

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -1,7 +1,9 @@
 [blockchain]
-name = "btc"
+name = "cardano"
 db_path = "/tmp/chain-indexer"
-api_host = "http://127.0.0.1:8332"
+socket_path = "/home/lisak/.cardano/db/node.socket"
+api_host = "localhost:1337"
+#api_host = "http://127.0.0.1:8332"
 
 [indexer]
 db_indexes = ["SCRIPT_HASH", "ADDRESS"] ## order matters, it affects data layout

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,15 +9,6 @@ use crate::{
     rocks_db_batch::{CustomFamilies, Families},
 };
 
-pub trait BlockchainClient {
-    type Tx: Send;
-
-    fn get_best_block(&self) -> Result<Block<Self::Tx>, String>;
-
-    fn get_block_by_height(&self, height: BlockHeight) -> Result<Block<Self::Tx>, String>;
-    fn get_block_by_hash(&self, height: BlockHash) -> Result<Block<Self::Tx>, String>;
-}
-
 pub trait BlockProcessor {
     type InTx: Send;
     type OutTx: Send;

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use lru::LruCache;
-use rocksdb::{MultiThreaded, OptimisticTransactionDB, WriteBatchWithTransaction};
-
 use crate::{
     codec_tx::TxPkBytes,
     model::{Block, BlockHash, BlockHeight, Transaction, TxCount, TxHash},
     rocks_db_batch::{CustomFamilies, Families},
 };
+use async_trait::async_trait;
+use lru::LruCache;
+use rocksdb::{MultiThreaded, OptimisticTransactionDB, WriteBatchWithTransaction};
 
 pub trait BlockProcessor {
     type InTx: Send;
@@ -22,6 +22,7 @@ pub trait BlockProcessor {
     ) -> (Vec<Block<Self::OutTx>>, TxCount);
 }
 
+#[async_trait]
 pub trait BlockProvider {
     type InTx: Send;
     type OutTx: Send;
@@ -32,9 +33,9 @@ pub trait BlockProvider {
         tx_count: TxCount,
     ) -> (Vec<Block<Self::OutTx>>, TxCount);
 
-    fn get_best_block(&self) -> Result<Block<Self::InTx>, String>;
+    async fn get_best_block(&self) -> Result<Block<Self::InTx>, String>;
 
-    fn get_block_by_height(&self, height: BlockHeight) -> Result<Block<Self::InTx>, String>;
+    async fn get_block_by_height(&self, height: BlockHeight) -> Result<Block<Self::InTx>, String>;
 
     fn get_processed_block_by_hash(&self, hash: BlockHash) -> Result<Block<Self::OutTx>, String>;
 }

--- a/src/block_service.rs
+++ b/src/block_service.rs
@@ -181,7 +181,7 @@ impl<'db, Tx: Transaction, CF: CustomFamilies<'db>> BlockService<'db, Tx, CF> {
             return Ok(Some(value.header.clone()));
         } else {
             let header_bytes = db_tx.get_cf(&families.shared.block_pk_by_hash_cf, block_hash)?;
-            Ok(header_bytes.map(|bytes| codec_block::bytes_to_block_header(&block_hash.0, &bytes)))
+            Ok(header_bytes.map(|bytes| codec_block::bytes_to_block_header(&bytes)))
         }
     }
 

--- a/src/eutxo/btc/btc_block_provider.rs
+++ b/src/eutxo/btc/btc_block_provider.rs
@@ -1,51 +1,85 @@
-use async_trait::async_trait;
-
 use crate::{
     api::{BlockProcessor, BlockProvider},
     eutxo::eutxo_model::EuTx,
-    model::{Block, BlockHash, BlockHeight, TxCount},
+    info,
+    model::{Block, BlockHeader, TxCount},
 };
+use async_trait::async_trait;
+use futures::stream::StreamExt;
+use futures::Stream;
+use min_batch::ext::MinBatchExt;
+use std::{pin::Pin, sync::Arc};
 
 use super::{btc_client::BtcClient, btc_processor::BtcProcessor};
 
 pub struct BtcBlockProvider {
-    pub client: BtcClient,
-    pub processor: BtcProcessor,
+    pub client: Arc<BtcClient>,
+    pub processor: Arc<BtcProcessor>,
 }
 
 impl BtcBlockProvider {
     pub fn new(api_host: &str, api_username: &str, api_password: &str) -> Self {
         BtcBlockProvider {
-            client: BtcClient::new(api_host, api_username, api_password),
-            processor: BtcProcessor {},
+            client: Arc::new(BtcClient::new(api_host, api_username, api_password)),
+            processor: Arc::new(BtcProcessor {}),
         }
+    }
+
+    pub fn process_batch(
+        &self,
+        block_batch: &Vec<Block<bitcoin::Transaction>>,
+        tx_count: TxCount,
+    ) -> (Vec<Block<EuTx>>, TxCount) {
+        self.processor.process_batch(block_batch, tx_count)
+    }
+
+    pub(crate) async fn get_best_block_header(&self) -> Result<BlockHeader, String> {
+        self.client.get_best_block()
     }
 }
 
 #[async_trait]
 impl BlockProvider for BtcBlockProvider {
-    type InTx = bitcoin::Transaction;
     type OutTx = EuTx;
 
-    fn process_batch(
-        &self,
-        block_batch: &Vec<Block<Self::InTx>>,
-        tx_count: TxCount,
-    ) -> (Vec<Block<Self::OutTx>>, TxCount) {
-        self.processor.process_batch(block_batch, tx_count)
-    }
-
-    async fn get_best_block(&self) -> Result<Block<Self::InTx>, String> {
-        self.client.get_best_block()
-    }
-
-    async fn get_block_by_height(&self, height: BlockHeight) -> Result<Block<Self::InTx>, String> {
-        self.client.get_block_by_height(height)
-    }
-
-    fn get_processed_block_by_hash(&self, hash: BlockHash) -> Result<Block<Self::OutTx>, String> {
-        let block = self.client.get_block_by_hash(hash)?;
+    fn get_processed_block(&self, header: BlockHeader) -> Result<Block<Self::OutTx>, String> {
+        let block = self.client.get_block_by_hash(header.hash)?;
         let processed_block = self.processor.process(&block);
         Ok(processed_block)
+    }
+
+    async fn stream(
+        &self,
+        last_header: Option<BlockHeader>,
+        min_batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = (Vec<Block<EuTx>>, TxCount)> + Send + 'life0>> {
+        let best_header = self.get_best_block_header().await.unwrap();
+        let last_height = last_header.map_or(0, |h| h.height.0);
+        info!("Initiating index from {} to {}", last_height, best_header);
+        let heights = last_height..=best_header.height.0;
+
+        tokio_stream::iter(heights)
+            .map(|height| {
+                let client = Arc::clone(&self.client);
+                tokio::task::spawn_blocking(move || {
+                    client.get_block_by_height(height.into()).unwrap()
+                })
+            })
+            .buffered(num_cpus::get())
+            .map(|res| match res {
+                Ok(block) => block,
+                Err(e) => panic!("Error: {:?}", e),
+            })
+            .min_batch_with_weight(min_batch_size, |block| block.txs.len())
+            .map(|(blocks, tx_count)| {
+                let processor = Arc::clone(&self.processor);
+                tokio::task::spawn_blocking(move || processor.process_batch(&blocks, tx_count))
+            })
+            .buffered(num_cpus::get())
+            .map(|res| match res {
+                Ok(block) => block,
+                Err(e) => panic!("Error: {:?}", e),
+            })
+            .boxed()
     }
 }

--- a/src/eutxo/btc/btc_block_provider.rs
+++ b/src/eutxo/btc/btc_block_provider.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use crate::{
     api::{BlockProcessor, BlockProvider},
     eutxo::eutxo_model::EuTx,
@@ -20,6 +22,7 @@ impl BtcBlockProvider {
     }
 }
 
+#[async_trait]
 impl BlockProvider for BtcBlockProvider {
     type InTx = bitcoin::Transaction;
     type OutTx = EuTx;
@@ -32,11 +35,11 @@ impl BlockProvider for BtcBlockProvider {
         self.processor.process_batch(block_batch, tx_count)
     }
 
-    fn get_best_block(&self) -> Result<Block<Self::InTx>, String> {
+    async fn get_best_block(&self) -> Result<Block<Self::InTx>, String> {
         self.client.get_best_block()
     }
 
-    fn get_block_by_height(&self, height: BlockHeight) -> Result<Block<Self::InTx>, String> {
+    async fn get_block_by_height(&self, height: BlockHeight) -> Result<Block<Self::InTx>, String> {
         self.client.get_block_by_height(height)
     }
 

--- a/src/eutxo/btc/btc_client.rs
+++ b/src/eutxo/btc/btc_client.rs
@@ -32,7 +32,7 @@ impl TryFrom<bitcoin::Block> for Block<bitcoin::Transaction> {
 }
 
 impl BtcClient {
-    pub fn get_best_block(&self) -> Result<Block<bitcoin::Transaction>, String> {
+    pub fn get_best_block(&self) -> Result<BlockHeader, String> {
         self.rpc_client
             .get_best_block_hash()
             .map_err(|e| e.to_string())
@@ -42,7 +42,8 @@ impl BtcClient {
                     .get_block(&hash)
                     .map_err(|e| e.to_string())?;
 
-                block.try_into()
+                let b: Block<bitcoin::Transaction> = block.try_into()?;
+                Ok(b.header)
             })
     }
 

--- a/src/eutxo/btc/btc_client.rs
+++ b/src/eutxo/btc/btc_client.rs
@@ -1,14 +1,7 @@
-use crate::api::BlockchainClient;
 use crate::model::{Block, BlockHash, BlockHeader, BlockHeight};
 use bitcoin_hashes::Hash;
 use bitcoincore_rpc::{Auth, Client, RpcApi};
 use std::sync::Arc;
-
-#[derive(Debug)]
-pub struct BtcTx {
-    pub height: BlockHeight, // expensive to calculate
-    pub delegate: bitcoin::Block,
-}
 
 pub struct BtcClient {
     rpc_client: Arc<Client>,
@@ -38,10 +31,8 @@ impl TryFrom<bitcoin::Block> for Block<bitcoin::Transaction> {
     }
 }
 
-impl BlockchainClient for BtcClient {
-    type Tx = bitcoin::Transaction;
-
-    fn get_best_block(&self) -> Result<Block<bitcoin::Transaction>, String> {
+impl BtcClient {
+    pub fn get_best_block(&self) -> Result<Block<bitcoin::Transaction>, String> {
         self.rpc_client
             .get_best_block_hash()
             .map_err(|e| e.to_string())
@@ -55,7 +46,10 @@ impl BlockchainClient for BtcClient {
             })
     }
 
-    fn get_block_by_hash(&self, hash: BlockHash) -> Result<Block<Self::Tx>, String> {
+    pub fn get_block_by_hash(
+        &self,
+        hash: BlockHash,
+    ) -> Result<Block<bitcoin::Transaction>, String> {
         let bitcoin_hash = bitcoin::BlockHash::from_slice(&hash.0).unwrap();
         let block = self
             .rpc_client
@@ -65,7 +59,10 @@ impl BlockchainClient for BtcClient {
         block.try_into()
     }
 
-    fn get_block_by_height(&self, height: BlockHeight) -> Result<Block<Self::Tx>, String> {
+    pub fn get_block_by_height(
+        &self,
+        height: BlockHeight,
+    ) -> Result<Block<bitcoin::Transaction>, String> {
         self.rpc_client
             .get_block_hash(height.0 as u64)
             .map_err(|e| e.to_string())

--- a/src/eutxo/cardano/cardano_block_provider.rs
+++ b/src/eutxo/cardano/cardano_block_provider.rs
@@ -1,0 +1,112 @@
+use pallas::network::miniprotocols::chainsync::NextResponse;
+use pallas::network::miniprotocols::Point;
+use tokio::runtime::Runtime;
+
+use crate::{
+    api::BlockProvider,
+    eutxo::eutxo_model::EuTx,
+    model::{Block, BlockHeader, TxCount},
+};
+use std::{pin::Pin, sync::Arc};
+
+use crate::info;
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use min_batch::ext::MinBatchExt;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+use super::{
+    cardano_client::{CardanoClient, CBOR},
+    cardano_processor::CardanoProcessor,
+};
+
+pub struct CardanoBlockProvider {
+    pub client: CardanoClient,
+    pub processor: Arc<CardanoProcessor>,
+}
+
+impl CardanoBlockProvider {
+    pub async fn new(api_host: &str, socket_path: &str) -> Self {
+        CardanoBlockProvider {
+            client: CardanoClient::new(api_host, socket_path).await,
+            processor: Arc::new(CardanoProcessor {}),
+        }
+    }
+}
+
+#[async_trait]
+impl BlockProvider for CardanoBlockProvider {
+    type OutTx = EuTx;
+
+    fn get_processed_block(&self, h: BlockHeader) -> Result<Block<Self::OutTx>, String> {
+        let point = Point::new(h.timestamp.0 as u64, h.hash.0.to_vec());
+        let rt = Runtime::new().unwrap();
+        let cbor = rt.block_on(self.client.get_block_by_point(point))?;
+        self.processor.process_block(&cbor)
+    }
+
+    async fn stream(
+        &self,
+        last_header: Option<BlockHeader>,
+        min_batch_size: usize,
+    ) -> Pin<Box<dyn Stream<Item = (Vec<Block<EuTx>>, TxCount)> + Send + 'life0>> {
+        let last_point = last_header.map_or(Point::Origin, |h| {
+            Point::new(h.timestamp.0 as u64, h.hash.0.to_vec())
+        });
+
+        let (tx, rx) = mpsc::channel::<CBOR>(100);
+        let node_client = Arc::clone(&self.client.node_client);
+
+        tokio::spawn(async move {
+            let node_client = Arc::clone(&node_client);
+            let (from, to) = node_client
+                .lock()
+                .await
+                .chainsync()
+                .find_intersect(vec![last_point])
+                .await
+                .unwrap();
+
+            info!(
+                "Streaming cardano blocks from {:?} to {:?}",
+                from.unwrap_or(Point::Origin),
+                to
+            );
+            loop {
+                match node_client
+                    .lock()
+                    .await
+                    .chainsync()
+                    .request_or_await_next()
+                    .await
+                    .unwrap()
+                {
+                    NextResponse::RollForward(block_bytes, _) => {
+                        if tx.send(block_bytes.0).await.is_err() {
+                            break;
+                        }
+                    }
+                    // Since we're just scraping data until we catch up, we don't need to handle rollbacks
+                    NextResponse::RollBackward(_, _) => {}
+                    // Await is returned once we've caught up, and we should let
+                    // the node notify us when there's a new block available
+                    NextResponse::Await => break,
+                }
+            }
+        });
+
+        ReceiverStream::new(rx)
+            .map(|cbor| {
+                let processor = Arc::clone(&self.processor);
+                tokio::task::spawn_blocking(move || processor.process_block(&cbor).unwrap())
+            })
+            .buffered(num_cpus::get())
+            .map(|res| match res {
+                Ok(block) => block,
+                Err(e) => panic!("Error: {:?}", e),
+            })
+            .min_batch_with_weight(min_batch_size, |block| block.txs.len())
+            .boxed()
+    }
+}

--- a/src/eutxo/cardano/cardano_client.rs
+++ b/src/eutxo/cardano/cardano_client.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use futures::lock::Mutex;
+use pallas::network::{
+    facades::{NodeClient, PeerClient},
+    miniprotocols::{localstate::queries_v16, Point, MAINNET_MAGIC},
+};
+
+pub type CBOR = Vec<u8>;
+
+pub struct CardanoClient {
+    pub peer_client: Arc<Mutex<PeerClient>>,
+    pub node_client: Arc<Mutex<NodeClient>>,
+}
+
+impl CardanoClient {
+    pub async fn new(api_host: &str, socket_path: &str) -> Self {
+        let peer_client = Arc::new(Mutex::new(
+            PeerClient::connect(api_host, MAINNET_MAGIC).await.unwrap(),
+        ));
+        let node_client = Arc::new(Mutex::new(
+            NodeClient::connect(socket_path, MAINNET_MAGIC)
+                .await
+                .unwrap(),
+        ));
+        CardanoClient {
+            peer_client,
+            node_client,
+        }
+    }
+}
+
+impl CardanoClient {
+    pub async fn get_best_block(&self) -> Result<CBOR, String> {
+        let mut client = self.node_client.lock().await;
+        let tip = queries_v16::get_chain_point(client.statequery())
+            .await
+            .map_err(|e| e.to_string())?;
+        self.get_block_by_point(tip).await
+    }
+
+    pub async fn get_block_by_point(&self, point: Point) -> Result<CBOR, String> {
+        let block_str = self
+            .peer_client
+            .lock()
+            .await
+            .blockfetch()
+            .fetch_single(point)
+            .await
+            .map_err(|e| e.to_string())?;
+        hex::decode(&block_str).map_err(|e| e.to_string())
+    }
+}

--- a/src/eutxo/cardano/cardano_processor.rs
+++ b/src/eutxo/cardano/cardano_processor.rs
@@ -1,0 +1,46 @@
+use pallas::ledger::traverse::MultiEraBlock;
+
+use crate::{
+    eutxo::eutxo_model::EuTx,
+    model::{Block, BlockHash, BlockHeader, TxIndex},
+};
+
+use super::cardano_client::CBOR;
+
+pub struct CardanoProcessor {}
+
+impl CardanoProcessor {
+    pub fn process_block(&self, block: &CBOR) -> Result<Block<EuTx>, String> {
+        let b = MultiEraBlock::decode(block).map_err(|e| e.to_string())?;
+
+        let hash: [u8; 32] = *b.header().hash();
+        let prev_h = b
+            .header()
+            .previous_hash()
+            .unwrap_or(pallas::crypto::hash::Hash::new([0u8; 32]));
+        let prev_hash: [u8; 32] = *prev_h;
+        let header = BlockHeader {
+            height: (b.header().number() as u32).into(),
+            timestamp: (b.header().slot() as u32).into(),
+            hash: BlockHash(hash),
+            prev_hash: BlockHash(prev_hash),
+        };
+
+        Ok(Block::new(
+            header,
+            b.txs()
+                .iter()
+                .enumerate()
+                .map(|(tx_index, tx)| {
+                    let tx_hash: [u8; 32] = *tx.hash();
+                    EuTx {
+                        tx_hash: tx_hash.into(),
+                        tx_index: TxIndex(tx_index as u16),
+                        tx_inputs: vec![],  // todo !!!
+                        tx_outputs: vec![], // todo !!!
+                    }
+                })
+                .collect(),
+        ))
+    }
+}

--- a/src/eutxo/cardano/mod.rs
+++ b/src/eutxo/cardano/mod.rs
@@ -1,0 +1,3 @@
+pub mod cardano_block_provider;
+pub mod cardano_client;
+pub mod cardano_processor;

--- a/src/eutxo/ergo/ergo_block_provider.rs
+++ b/src/eutxo/ergo/ergo_block_provider.rs
@@ -1,27 +1,30 @@
+use ergo_lib::chain::transaction::Transaction;
+use reqwest::Url;
+
 use crate::{
     api::{BlockProcessor, BlockProvider},
     eutxo::eutxo_model::EuTx,
     model::{Block, BlockHash, BlockHeight, TxCount},
 };
 
-use super::{btc_client::BtcClient, btc_processor::BtcProcessor};
+use super::{ergo_client::ErgoClient, ergo_processor::ErgoProcessor};
 
-pub struct BtcBlockProvider {
-    pub client: BtcClient,
-    pub processor: BtcProcessor,
+pub struct ErgoBlockProvider {
+    pub client: ErgoClient,
+    pub processor: ErgoProcessor,
 }
 
-impl BtcBlockProvider {
-    pub fn new(api_host: &str, api_username: &str, api_password: &str) -> Self {
-        BtcBlockProvider {
-            client: BtcClient::new(api_host, api_username, api_password),
-            processor: BtcProcessor {},
+impl ErgoBlockProvider {
+    pub fn new(node_url: Url, api_key: Option<&'static str>) -> Self {
+        ErgoBlockProvider {
+            client: ErgoClient { node_url, api_key },
+            processor: ErgoProcessor {},
         }
     }
 }
 
-impl BlockProvider for BtcBlockProvider {
-    type InTx = bitcoin::Transaction;
+impl BlockProvider for ErgoBlockProvider {
+    type InTx = Transaction;
     type OutTx = EuTx;
 
     fn process_batch(

--- a/src/eutxo/ergo/ergo_block_provider.rs
+++ b/src/eutxo/ergo/ergo_block_provider.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use ergo_lib::chain::transaction::Transaction;
 use reqwest::Url;
 
@@ -23,6 +24,7 @@ impl ErgoBlockProvider {
     }
 }
 
+#[async_trait]
 impl BlockProvider for ErgoBlockProvider {
     type InTx = Transaction;
     type OutTx = EuTx;
@@ -35,16 +37,16 @@ impl BlockProvider for ErgoBlockProvider {
         self.processor.process_batch(block_batch, tx_count)
     }
 
-    fn get_best_block(&self) -> Result<Block<Self::InTx>, String> {
-        self.client.get_best_block()
+    async fn get_best_block(&self) -> Result<Block<Self::InTx>, String> {
+        self.client.get_best_block_async().await
     }
 
-    fn get_block_by_height(&self, height: BlockHeight) -> Result<Block<Self::InTx>, String> {
-        self.client.get_block_by_height(height)
+    async fn get_block_by_height(&self, height: BlockHeight) -> Result<Block<Self::InTx>, String> {
+        self.client.get_block_by_height_async(height).await
     }
 
     fn get_processed_block_by_hash(&self, hash: BlockHash) -> Result<Block<Self::OutTx>, String> {
-        let block = self.client.get_block_by_hash(hash)?;
+        let block = self.client.get_block_by_hash_sync(hash)?;
         let processed_block = self.processor.process(&block);
         Ok(processed_block)
     }

--- a/src/eutxo/ergo/ergo_client.rs
+++ b/src/eutxo/ergo/ergo_client.rs
@@ -1,0 +1,108 @@
+use crate::model::{Block, BlockHash, BlockHeader, BlockHeight};
+use ergo_lib::chain::block::FullBlock;
+use ergo_lib::chain::transaction::Transaction;
+use reqwest::{
+    blocking::{Client, RequestBuilder},
+    header::{HeaderValue, CONTENT_TYPE},
+    Url,
+};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[repr(C)]
+pub struct NodeInfo {
+    pub name: String,
+    #[serde(rename = "appVersion")]
+    pub app_version: String,
+    #[serde(rename = "fullHeight")]
+    pub full_height: u32,
+}
+
+pub struct ErgoClient {
+    pub(crate) node_url: Url,
+    pub(crate) api_key: Option<&'static str>,
+}
+
+impl ErgoClient {
+    pub fn get_node_api_header(&self) -> HeaderValue {
+        match self.api_key {
+            Some(api_key) => match HeaderValue::from_str(api_key) {
+                Ok(k) => k,
+                _ => HeaderValue::from_static("None"),
+            },
+            None => HeaderValue::from_static("None"),
+        }
+    }
+
+    fn set_req_headers(&self, rb: RequestBuilder) -> RequestBuilder {
+        rb.header("accept", "application/json")
+            .header("api_key", self.get_node_api_header())
+            .header(CONTENT_TYPE, "application/json")
+    }
+}
+
+impl ErgoClient {
+    fn build_client(&self) -> Result<Client, String> {
+        let builder = Client::builder();
+        builder
+            .timeout(Duration::from_millis(3000))
+            .build()
+            .map_err(|e| e.to_string())
+    }
+
+    pub(crate) fn get_best_block(&self) -> Result<Block<Transaction>, String> {
+        let url = self.node_url.join("info").unwrap();
+        let rb = self.build_client()?.get(url);
+        let node_info = self
+            .set_req_headers(rb)
+            .send()
+            .map_err(|e| e.to_string())?
+            .json::<NodeInfo>()
+            .map_err(|e| e.to_string())?;
+
+        self.get_block_by_height(node_info.full_height.into())
+    }
+
+    pub(crate) fn get_block_by_height(
+        &self,
+        height: BlockHeight,
+    ) -> Result<Block<Transaction>, String> {
+        let mut path = "blocks/at/".to_owned();
+        path.push_str(&height.0.to_string());
+        #[allow(clippy::unwrap_used)]
+        let url = self.node_url.join(&path).unwrap();
+        self.get_block_by_url(url)
+    }
+
+    fn get_block_by_url(&self, url: Url) -> Result<Block<Transaction>, String> {
+        let rb = self.build_client()?.get(url);
+        let block = self
+            .set_req_headers(rb)
+            .send()
+            .map_err(|e| e.to_string())?
+            .json::<FullBlock>()
+            .map_err(|e| e.to_string())?;
+        let block_hash: [u8; 32] = block.header.id.0.into();
+        let prev_block_hash: [u8; 32] = block.header.parent_id.0.into();
+        let header = BlockHeader {
+            height: block.header.height.into(),
+            timestamp: (block.header.timestamp as u32).into(),
+            hash: block_hash.into(),
+            prev_hash: prev_block_hash.into(),
+        };
+        Ok(Block::new(
+            header,
+            block.block_transactions.transactions.to_vec(),
+        ))
+    }
+
+    pub(crate) fn get_block_by_hash(&self, hash: BlockHash) -> Result<Block<Transaction>, String> {
+        let mut path = "blocks/".to_owned();
+        let block_hash: String = hex::encode(hash.0);
+        path.push_str(&block_hash);
+        #[allow(clippy::unwrap_used)]
+        let url = self.node_url.join(&path).unwrap();
+        self.get_block_by_url(url)
+    }
+}

--- a/src/eutxo/ergo/ergo_client.rs
+++ b/src/eutxo/ergo/ergo_client.rs
@@ -2,9 +2,9 @@ use crate::model::{Block, BlockHash, BlockHeader, BlockHeight};
 use ergo_lib::chain::block::FullBlock;
 use ergo_lib::chain::transaction::Transaction;
 use reqwest::{
-    blocking::{Client, RequestBuilder},
+    blocking,
     header::{HeaderValue, CONTENT_TYPE},
-    Url,
+    Client, RequestBuilder, Url,
 };
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -35,15 +35,13 @@ impl ErgoClient {
         }
     }
 
-    fn set_req_headers(&self, rb: RequestBuilder) -> RequestBuilder {
+    fn set_async_req_headers(&self, rb: RequestBuilder) -> RequestBuilder {
         rb.header("accept", "application/json")
             .header("api_key", self.get_node_api_header())
             .header(CONTENT_TYPE, "application/json")
     }
-}
 
-impl ErgoClient {
-    fn build_client(&self) -> Result<Client, String> {
+    fn build_async_client(&self) -> Result<Client, String> {
         let builder = Client::builder();
         builder
             .timeout(Duration::from_millis(3000))
@@ -51,20 +49,50 @@ impl ErgoClient {
             .map_err(|e| e.to_string())
     }
 
-    pub(crate) fn get_best_block(&self) -> Result<Block<Transaction>, String> {
+    fn set_blocking_req_headers(&self, rb: blocking::RequestBuilder) -> blocking::RequestBuilder {
+        rb.header("accept", "application/json")
+            .header("api_key", self.get_node_api_header())
+            .header(CONTENT_TYPE, "application/json")
+    }
+
+    fn build_blocking_client(&self) -> Result<blocking::Client, String> {
+        let builder = blocking::Client::builder();
+        builder
+            .timeout(Duration::from_millis(3000))
+            .build()
+            .map_err(|e| e.to_string())
+    }
+
+    pub(crate) async fn get_best_block_async(&self) -> Result<Block<Transaction>, String> {
         let url = self.node_url.join("info").unwrap();
-        let rb = self.build_client()?.get(url);
+        let rb = self.build_async_client()?.get(url);
         let node_info = self
-            .set_req_headers(rb)
+            .set_async_req_headers(rb)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?
+            .json::<NodeInfo>()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        self.get_block_by_height_async(node_info.full_height.into())
+            .await
+    }
+
+    pub(crate) fn get_best_block_sync(&self) -> Result<Block<Transaction>, String> {
+        let url = self.node_url.join("info").unwrap();
+        let rb = self.build_blocking_client()?.get(url);
+        let node_info = self
+            .set_blocking_req_headers(rb)
             .send()
             .map_err(|e| e.to_string())?
             .json::<NodeInfo>()
             .map_err(|e| e.to_string())?;
 
-        self.get_block_by_height(node_info.full_height.into())
+        self.get_block_by_height_sync(node_info.full_height.into())
     }
 
-    pub(crate) fn get_block_by_height(
+    pub(crate) async fn get_block_by_height_async(
         &self,
         height: BlockHeight,
     ) -> Result<Block<Transaction>, String> {
@@ -72,13 +100,24 @@ impl ErgoClient {
         path.push_str(&height.0.to_string());
         #[allow(clippy::unwrap_used)]
         let url = self.node_url.join(&path).unwrap();
-        self.get_block_by_url(url)
+        self.get_block_by_url_async(url).await
     }
 
-    fn get_block_by_url(&self, url: Url) -> Result<Block<Transaction>, String> {
-        let rb = self.build_client()?.get(url);
+    pub(crate) fn get_block_by_height_sync(
+        &self,
+        height: BlockHeight,
+    ) -> Result<Block<Transaction>, String> {
+        let mut path = "blocks/at/".to_owned();
+        path.push_str(&height.0.to_string());
+        #[allow(clippy::unwrap_used)]
+        let url = self.node_url.join(&path).unwrap();
+        self.get_block_by_url_sync(url)
+    }
+
+    fn get_block_by_url_sync(&self, url: Url) -> Result<Block<Transaction>, String> {
+        let rb = self.build_blocking_client()?.get(url);
         let block = self
-            .set_req_headers(rb)
+            .set_blocking_req_headers(rb)
             .send()
             .map_err(|e| e.to_string())?
             .json::<FullBlock>()
@@ -97,12 +136,50 @@ impl ErgoClient {
         ))
     }
 
-    pub(crate) fn get_block_by_hash(&self, hash: BlockHash) -> Result<Block<Transaction>, String> {
+    async fn get_block_by_url_async(&self, url: Url) -> Result<Block<Transaction>, String> {
+        let rb = self.build_async_client()?.get(url);
+        let block = self
+            .set_async_req_headers(rb)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?
+            .json::<FullBlock>()
+            .await
+            .map_err(|e| e.to_string())?;
+        let block_hash: [u8; 32] = block.header.id.0.into();
+        let prev_block_hash: [u8; 32] = block.header.parent_id.0.into();
+        let header = BlockHeader {
+            height: block.header.height.into(),
+            timestamp: (block.header.timestamp as u32).into(),
+            hash: block_hash.into(),
+            prev_hash: prev_block_hash.into(),
+        };
+        Ok(Block::new(
+            header,
+            block.block_transactions.transactions.to_vec(),
+        ))
+    }
+
+    pub(crate) fn get_block_by_hash_sync(
+        &self,
+        hash: BlockHash,
+    ) -> Result<Block<Transaction>, String> {
         let mut path = "blocks/".to_owned();
         let block_hash: String = hex::encode(hash.0);
         path.push_str(&block_hash);
         #[allow(clippy::unwrap_used)]
         let url = self.node_url.join(&path).unwrap();
-        self.get_block_by_url(url)
+        self.get_block_by_url_sync(url)
+    }
+    pub(crate) async fn get_block_by_hash_async(
+        &self,
+        hash: BlockHash,
+    ) -> Result<Block<Transaction>, String> {
+        let mut path = "blocks/".to_owned();
+        let block_hash: String = hex::encode(hash.0);
+        path.push_str(&block_hash);
+        #[allow(clippy::unwrap_used)]
+        let url = self.node_url.join(&path).unwrap();
+        self.get_block_by_url_async(url).await
     }
 }

--- a/src/eutxo/ergo/ergo_client.rs
+++ b/src/eutxo/ergo/ergo_client.rs
@@ -79,19 +79,6 @@ impl ErgoClient {
             .await
     }
 
-    pub(crate) fn get_best_block_sync(&self) -> Result<Block<Transaction>, String> {
-        let url = self.node_url.join("info").unwrap();
-        let rb = self.build_blocking_client()?.get(url);
-        let node_info = self
-            .set_blocking_req_headers(rb)
-            .send()
-            .map_err(|e| e.to_string())?
-            .json::<NodeInfo>()
-            .map_err(|e| e.to_string())?;
-
-        self.get_block_by_height_sync(node_info.full_height.into())
-    }
-
     pub(crate) async fn get_block_by_height_async(
         &self,
         height: BlockHeight,
@@ -101,17 +88,6 @@ impl ErgoClient {
         #[allow(clippy::unwrap_used)]
         let url = self.node_url.join(&path).unwrap();
         self.get_block_by_url_async(url).await
-    }
-
-    pub(crate) fn get_block_by_height_sync(
-        &self,
-        height: BlockHeight,
-    ) -> Result<Block<Transaction>, String> {
-        let mut path = "blocks/at/".to_owned();
-        path.push_str(&height.0.to_string());
-        #[allow(clippy::unwrap_used)]
-        let url = self.node_url.join(&path).unwrap();
-        self.get_block_by_url_sync(url)
     }
 
     fn get_block_by_url_sync(&self, url: Url) -> Result<Block<Transaction>, String> {
@@ -170,16 +146,5 @@ impl ErgoClient {
         #[allow(clippy::unwrap_used)]
         let url = self.node_url.join(&path).unwrap();
         self.get_block_by_url_sync(url)
-    }
-    pub(crate) async fn get_block_by_hash_async(
-        &self,
-        hash: BlockHash,
-    ) -> Result<Block<Transaction>, String> {
-        let mut path = "blocks/".to_owned();
-        let block_hash: String = hex::encode(hash.0);
-        path.push_str(&block_hash);
-        #[allow(clippy::unwrap_used)]
-        let url = self.node_url.join(&path).unwrap();
-        self.get_block_by_url_async(url).await
     }
 }

--- a/src/eutxo/ergo/ergo_processor.rs
+++ b/src/eutxo/ergo/ergo_processor.rs
@@ -2,8 +2,8 @@ use ergo_lib::chain::transaction::Transaction;
 
 use crate::{
     api::BlockProcessor,
-    eutxo::eutxo_model::{EuTx, EuTxInput},
-    model::{Block, TxCount, TxIndex},
+    eutxo::eutxo_model::EuTx,
+    model::{Block, TxCount},
 };
 
 pub struct ErgoProcessor {}

--- a/src/eutxo/ergo/ergo_processor.rs
+++ b/src/eutxo/ergo/ergo_processor.rs
@@ -1,0 +1,110 @@
+use ergo_lib::chain::transaction::Transaction;
+
+use crate::{
+    api::BlockProcessor,
+    eutxo::eutxo_model::{EuTx, EuTxInput},
+    model::{Block, TxCount, TxIndex},
+};
+
+pub struct ErgoProcessor {}
+
+impl BlockProcessor for ErgoProcessor {
+    type InTx = Transaction;
+    type OutTx = EuTx;
+
+    fn process(&self, btc_block: &Block<Self::InTx>) -> Block<Self::OutTx> {
+        btc_block.into()
+    }
+
+    fn process_batch(
+        &self,
+        block_batch: &Vec<Block<Self::InTx>>,
+        tx_count: TxCount,
+    ) -> (Vec<Block<Self::OutTx>>, TxCount) {
+        (
+            block_batch
+                .into_iter()
+                .map(|btc_block| {
+                    let eu_block: Block<Self::OutTx> = btc_block.into();
+                    eu_block
+                })
+                .collect(),
+            tx_count,
+        )
+    }
+}
+
+impl From<&Block<Transaction>> for Block<EuTx> {
+    fn from(block: &Block<Transaction>) -> Self {
+        Block::new(
+            block.header.clone(),
+            vec![],
+            /*             block
+                           .txs
+                           .iter()
+                           .enumerate()
+                           .map(|(tx_index, tx)| (&(tx_index as u16).into(), tx).into())
+                           .collect(),
+            */
+        )
+    }
+}
+/*
+impl From<(&TxIndex, &Transaction)> for EuTx {
+    fn from(tx: (&TxIndex, &Transaction)) -> Self {
+        let tx_id: [u8; 32] = tx.1.id().0 .0;
+        EuTx {
+            tx_hash: tx_id.into(),
+            tx_index: tx.0.clone(),
+            tx_inputs: tx
+                .1
+                .inputs
+                .iter()
+                .map(|input| EuTxInput {
+                    tx_hash: input.previous_output.txid.to_byte_array().into(),
+                    utxo_index: (input.previous_output.vout as u16).into(),
+                })
+                .collect(),
+            tx_outputs: tx
+                .1
+                .output
+                .iter()
+                .enumerate()
+                .map(|(out_index, out)| {
+                    let address = if let Ok(address) =
+                        Address::from_script(out.script_pubkey.as_script(), Network::Bitcoin)
+                    {
+                        Some(address.to_string().into_bytes())
+                    } else if let Some(pk) = out.script_pubkey.p2pk_public_key() {
+                        Some(
+                            Address::p2pkh(pk.pubkey_hash(), Network::Bitcoin)
+                                .to_string()
+                                .into_bytes(),
+                        )
+                    } else if out.script_pubkey.is_op_return() {
+                        None
+                    } else {
+                        None
+                    };
+                    let script_hash = sha256::Hash::hash(out.script_pubkey.as_bytes())
+                        .as_byte_array()
+                        .to_vec();
+
+                    let mut db_indexes = Vec::with_capacity(2); // Pre-allocate capacity for 2 elements
+                    db_indexes.push((0, script_hash));
+                    if let Some(address) = address {
+                        db_indexes.push((1, address));
+                    }
+
+                    EuUtxo {
+                        utxo_index: (out_index as u16).into(),
+                        db_indexes,
+                        assets: EMPTY_VEC,
+                        utxo_value: out.value.to_sat().into(),
+                    }
+                })
+                .collect(),
+        }
+    }
+}
+ */

--- a/src/eutxo/ergo/mod.rs
+++ b/src/eutxo/ergo/mod.rs
@@ -1,0 +1,3 @@
+pub mod ergo_block_provider;
+pub mod ergo_client;
+pub mod ergo_processor;

--- a/src/eutxo/eutxo_executor.rs
+++ b/src/eutxo/eutxo_executor.rs
@@ -1,0 +1,99 @@
+use crate::api::Storage;
+use crate::eutxo::eutxo_model::*;
+
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use crate::block_service::BlockService;
+use crate::eutxo::eutxo_block_monitor::EuBlockMonitor;
+use crate::eutxo::eutxo_families::EutxoFamilies;
+use crate::eutxo::eutxo_index_manager::DbIndexManager;
+use crate::eutxo::eutxo_model::EuTx;
+use crate::eutxo::eutxo_tx_service::EuTxService;
+use crate::indexer::Indexer;
+use crate::info;
+use crate::model::*;
+use crate::rocks_db_batch::{Families, SharedFamilies};
+use crate::settings::AppConfig;
+use crate::syncer::ChainSyncer;
+use crate::{api::BlockProvider, eutxo::eutxo_storage};
+use rocksdb::BoundColumnFamily;
+
+pub async fn run_eutxo_indexing(
+    config: AppConfig,
+    block_provider: Arc<dyn BlockProvider<OutTx = EuTx>>,
+) {
+    let blockchain = config.blockchain;
+    let db_path: String = format!("{}/{}/{}", blockchain.db_path, "main", blockchain.name);
+    let db_indexes = config.indexer.db_indexes;
+    let disable_wal = config.indexer.disable_wal;
+
+    let tx_batch_size = config.indexer.tx_batch_size;
+
+    let db_index_manager = DbIndexManager::new(&db_indexes);
+    let db = Arc::new(eutxo_storage::get_db(&db_index_manager, &db_path));
+    let families = Arc::new(Families {
+        shared: SharedFamilies {
+            meta_cf: db.cf_handle(META_CF).unwrap(),
+            block_hash_by_pk_cf: db.cf_handle(BLOCK_PK_BY_HASH_CF).unwrap(),
+            block_pk_by_hash_cf: db.cf_handle(BLOCK_HASH_BY_PK_CF).unwrap(),
+            tx_hash_by_pk_cf: db.cf_handle(TX_HASH_BY_PK_CF).unwrap(),
+            tx_pk_by_hash_cf: db.cf_handle(TX_PK_BY_HASH_CF).unwrap(),
+        },
+        custom: EutxoFamilies {
+            utxo_value_by_pk_cf: db.cf_handle(UTXO_VALUE_BY_PK_CF).unwrap(),
+            utxo_pk_by_input_pk_cf: db.cf_handle(UTXO_PK_BY_INPUT_PK_CF).unwrap(),
+            utxo_birth_pk_with_utxo_pk_cf: db_index_manager
+                .utxo_birth_pk_relations
+                .iter()
+                .map(|cf| db.cf_handle(cf).unwrap())
+                .collect::<Vec<Arc<BoundColumnFamily>>>(),
+            utxo_birth_pk_by_index_cf: db_index_manager
+                .utxo_birth_pk_by_index
+                .iter()
+                .map(|cf| db.cf_handle(cf).unwrap())
+                .collect::<Vec<Arc<BoundColumnFamily>>>(),
+            index_by_utxo_birth_pk_cf: db_index_manager
+                .index_by_utxo_birth_pk
+                .iter()
+                .map(|cf| db.cf_handle(cf).unwrap())
+                .collect::<Vec<Arc<BoundColumnFamily>>>(),
+            assets_by_utxo_pk_cf: db.cf_handle(ASSETS_BY_UTXO_PK_CF).unwrap(),
+            asset_id_by_asset_birth_pk_cf: db.cf_handle(ASSET_ID_BY_ASSET_BIRTH_PK_CF).unwrap(),
+            asset_birth_pk_by_asset_id_cf: db.cf_handle(ASSET_BIRTH_PK_BY_ASSET_ID_CF).unwrap(),
+            asset_birth_pk_with_asset_pk_cf: db.cf_handle(ASSET_BIRTH_PK_WITH_ASSET_PK_CF).unwrap(),
+        },
+    });
+
+    let storage = Arc::new(RwLock::new(Storage {
+        db: Arc::clone(&db),
+    }));
+
+    let tx_service = Arc::new(EuTxService {});
+    let block_service = Arc::new(BlockService::new(tx_service));
+
+    let indexer = Arc::new(Indexer::new(
+        Arc::clone(&storage),
+        Arc::clone(&families),
+        block_service,
+        Arc::clone(&block_provider) as Arc<dyn BlockProvider<OutTx = EuTx>>,
+        disable_wal,
+    ));
+    let syncer = ChainSyncer::new(block_provider, Arc::new(EuBlockMonitor::new(1000)), indexer);
+    let storage = Arc::clone(&storage);
+    tokio::task::spawn(async move {
+        match tokio::signal::ctrl_c().await {
+            Ok(()) => {
+                info!("Received interrupt signal");
+                storage.write().unwrap().db.flush().unwrap();
+                info!("RocksDB successfully flushed and closed.");
+                std::process::exit(0);
+            }
+            Err(err) => {
+                eprintln!("Unable to listen for shutdown signal: {}", err);
+                std::process::exit(1);
+            }
+        }
+    });
+    syncer.sync(tx_batch_size).await
+}

--- a/src/eutxo/mod.rs
+++ b/src/eutxo/mod.rs
@@ -1,4 +1,5 @@
 pub mod btc;
+pub mod ergo;
 pub mod eutxo_block_monitor;
 pub mod eutxo_codec_utxo;
 pub mod eutxo_families;

--- a/src/eutxo/mod.rs
+++ b/src/eutxo/mod.rs
@@ -1,7 +1,8 @@
 pub mod btc;
-pub mod ergo;
+pub mod cardano;
 pub mod eutxo_block_monitor;
 pub mod eutxo_codec_utxo;
+pub mod eutxo_executor;
 pub mod eutxo_families;
 pub mod eutxo_index_manager;
 pub mod eutxo_model;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,134 +1,41 @@
-use ci::api::Storage;
-use ci::eutxo::eutxo_model::*;
+use ci::eutxo::cardano::cardano_block_provider::CardanoBlockProvider;
+use ci::eutxo::eutxo_executor;
 
 use std::sync::Arc;
-use std::sync::RwLock;
 
-use ci::block_service::BlockService;
 use ci::eutxo::btc::btc_block_provider::BtcBlockProvider;
-use ci::eutxo::eutxo_block_monitor::EuBlockMonitor;
-use ci::eutxo::eutxo_families::EutxoFamilies;
-use ci::eutxo::eutxo_index_manager::DbIndexManager;
-use ci::eutxo::eutxo_model::EuTx;
-use ci::eutxo::eutxo_tx_service::EuTxService;
-use ci::indexer::Indexer;
-use ci::info;
-use ci::model::*;
-use ci::rocks_db_batch::{Families, SharedFamilies};
 use ci::settings::AppConfig;
-use ci::syncer::ChainSyncer;
-use ci::{api::BlockProvider, eutxo::eutxo_storage};
-use rocksdb::BoundColumnFamily;
 
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     let config = AppConfig::new();
 
     match config {
-        Ok(config) => {
-            let blockchain = config.blockchain;
-            let api_host = blockchain.api_host;
-            let api_username = blockchain.api_username;
-            let api_password = blockchain.api_password;
-            let db_path: String = format!("{}/{}/{}", blockchain.db_path, "main", blockchain.name);
-            let db_indexes = config.indexer.db_indexes;
-            let disable_wal = config.indexer.disable_wal;
+        Ok(config) => match config.blockchain.name.as_str() {
+            "btc" => {
+                let api_host = &config.blockchain.api_host;
+                let api_username = &config.blockchain.api_username;
+                let api_password = &config.blockchain.api_password;
+                let block_provider =
+                    Arc::new(BtcBlockProvider::new(api_host, api_username, api_password));
 
-            let tx_batch_size = config.indexer.tx_batch_size;
-
-            match blockchain.name.as_str() {
-                "btc" => {
-                    let db_index_manager = DbIndexManager::new(&db_indexes);
-                    let db = Arc::new(eutxo_storage::get_db(&db_index_manager, &db_path));
-                    let families = Arc::new(Families {
-                        shared: SharedFamilies {
-                            meta_cf: db.cf_handle(META_CF).unwrap(),
-                            block_hash_by_pk_cf: db.cf_handle(BLOCK_PK_BY_HASH_CF).unwrap(),
-                            block_pk_by_hash_cf: db.cf_handle(BLOCK_HASH_BY_PK_CF).unwrap(),
-                            tx_hash_by_pk_cf: db.cf_handle(TX_HASH_BY_PK_CF).unwrap(),
-                            tx_pk_by_hash_cf: db.cf_handle(TX_PK_BY_HASH_CF).unwrap(),
-                        },
-                        custom: EutxoFamilies {
-                            utxo_value_by_pk_cf: db.cf_handle(UTXO_VALUE_BY_PK_CF).unwrap(),
-                            utxo_pk_by_input_pk_cf: db.cf_handle(UTXO_PK_BY_INPUT_PK_CF).unwrap(),
-                            utxo_birth_pk_with_utxo_pk_cf: db_index_manager
-                                .utxo_birth_pk_relations
-                                .iter()
-                                .map(|cf| db.cf_handle(cf).unwrap())
-                                .collect::<Vec<Arc<BoundColumnFamily>>>(),
-                            utxo_birth_pk_by_index_cf: db_index_manager
-                                .utxo_birth_pk_by_index
-                                .iter()
-                                .map(|cf| db.cf_handle(cf).unwrap())
-                                .collect::<Vec<Arc<BoundColumnFamily>>>(),
-                            index_by_utxo_birth_pk_cf: db_index_manager
-                                .index_by_utxo_birth_pk
-                                .iter()
-                                .map(|cf| db.cf_handle(cf).unwrap())
-                                .collect::<Vec<Arc<BoundColumnFamily>>>(),
-                            assets_by_utxo_pk_cf: db.cf_handle(ASSETS_BY_UTXO_PK_CF).unwrap(),
-                            asset_id_by_asset_birth_pk_cf: db
-                                .cf_handle(ASSET_ID_BY_ASSET_BIRTH_PK_CF)
-                                .unwrap(),
-                            asset_birth_pk_by_asset_id_cf: db
-                                .cf_handle(ASSET_BIRTH_PK_BY_ASSET_ID_CF)
-                                .unwrap(),
-                            asset_birth_pk_with_asset_pk_cf: db
-                                .cf_handle(ASSET_BIRTH_PK_WITH_ASSET_PK_CF)
-                                .unwrap(),
-                        },
-                    });
-
-                    let storage = Arc::new(RwLock::new(Storage {
-                        db: Arc::clone(&db),
-                    }));
-
-                    let tx_service = Arc::new(EuTxService {});
-                    let block_service = Arc::new(BlockService::new(tx_service));
-
-                    let block_provider: Arc<
-                        dyn BlockProvider<InTx = bitcoin::Transaction, OutTx = EuTx> + Send + Sync,
-                    > = Arc::new(BtcBlockProvider::new(
-                        &api_host,
-                        &api_username,
-                        &api_password,
-                    ));
-                    let indexer = Arc::new(Indexer::new(
-                        Arc::clone(&storage),
-                        Arc::clone(&families),
-                        block_service,
-                        Arc::clone(&block_provider),
-                        disable_wal,
-                    ));
-                    let syncer = ChainSyncer::new(
-                        Arc::clone(&block_provider),
-                        Arc::new(EuBlockMonitor::new(1000)),
-                        indexer,
-                    );
-                    let storage = Arc::clone(&storage);
-                    tokio::task::spawn(async move {
-                        match tokio::signal::ctrl_c().await {
-                            Ok(()) => {
-                                info!("Received interrupt signal");
-                                storage.write().unwrap().db.flush().unwrap();
-                                info!("RocksDB successfully flushed and closed.");
-                                std::process::exit(0);
-                            }
-                            Err(err) => {
-                                eprintln!("Unable to listen for shutdown signal: {}", err);
-                                std::process::exit(1);
-                            }
-                        }
-                    });
-                    syncer.sync(tx_batch_size).await;
-                    Ok(())
-                }
-                _ => {
-                    ci::error!("Unsupported blockchain: {}", blockchain.name);
-                    return Err(std::io::Error::new(std::io::ErrorKind::Other, "Error"));
-                }
+                eutxo_executor::run_eutxo_indexing(config, block_provider).await;
+                Ok(())
             }
-        }
+            "cardano" => {
+                let api_host = &config.blockchain.api_host;
+                let socket_path = &config.blockchain.socket_path;
+                let block_provider =
+                    Arc::new(CardanoBlockProvider::new(api_host, socket_path).await);
+
+                eutxo_executor::run_eutxo_indexing(config, block_provider).await;
+                Ok(())
+            }
+            _ => {
+                ci::error!("Unsupported blockchain: {}", config.blockchain.name);
+                return Err(std::io::Error::new(std::io::ErrorKind::Other, "Error"));
+            }
+        },
         Err(e) => {
             ci::error!("Error: {}", e);
             Err(std::io::Error::new(std::io::ErrorKind::Other, "Error"))

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,6 +15,7 @@ pub struct BlockchainSettings {
     pub name: String,
     pub db_path: String,
     pub api_host: String,
+    pub socket_path: String,
     pub api_username: String,
     pub api_password: String,
 }

--- a/src/syncer.rs
+++ b/src/syncer.rs
@@ -1,3 +1,5 @@
+use futures::StreamExt;
+
 use crate::{
     api::{BlockMonitor, BlockProvider},
     indexer::Indexer,
@@ -5,87 +7,45 @@ use crate::{
     model::Transaction,
     rocks_db_batch::CustomFamilies,
 };
-use futures::stream::StreamExt;
-
-use min_batch::ext::MinBatchExt;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
 
-pub struct ChainSyncer<
-    'db,
-    CF: CustomFamilies<'db>,
-    InTx: Send + 'static,
-    OutTx: Transaction + Send + 'static,
-> {
+pub struct ChainSyncer<'db, CF: CustomFamilies<'db>, OutTx: Transaction + Send + 'static> {
     pub is_shutdown: Arc<AtomicBool>,
-    pub block_provider: Arc<dyn BlockProvider<InTx = InTx, OutTx = OutTx> + Send + Sync>,
+    pub block_source: Arc<dyn BlockProvider<OutTx = OutTx>>,
     pub monitor: Arc<dyn BlockMonitor<OutTx>>,
-    pub indexer: Arc<Indexer<'db, CF, InTx, OutTx>>,
+    pub indexer: Arc<Indexer<'db, CF, OutTx>>,
 }
 
-impl<'db, CF: CustomFamilies<'db>, InTx: Send + 'static, OutTx: Transaction + Send + 'static>
-    ChainSyncer<'db, CF, InTx, OutTx>
+impl<'db, CF: CustomFamilies<'db>, OutTx: Transaction + Send + 'static>
+    ChainSyncer<'db, CF, OutTx>
 {
     pub fn new(
-        block_provider: Arc<dyn BlockProvider<InTx = InTx, OutTx = OutTx> + Send + Sync>,
+        block_provider: Arc<dyn BlockProvider<OutTx = OutTx>>,
         monitor: Arc<dyn BlockMonitor<OutTx>>,
-        indexer: Arc<Indexer<'db, CF, InTx, OutTx>>,
+        indexer: Arc<Indexer<'db, CF, OutTx>>,
     ) -> Self {
         ChainSyncer {
             is_shutdown: Arc::new(AtomicBool::new(false)),
-            block_provider,
+            block_source: block_provider,
             monitor,
             indexer,
         }
     }
 
     pub async fn sync(&self, min_batch_size: usize) {
-        let best_height = self
-            .block_provider
-            .get_best_block()
+        let is_chain_tip = false; // TODO check for ChainTip presence to start chainlinking
+        self.block_source
+            .stream(self.indexer.get_last_header(), min_batch_size)
             .await
-            .unwrap()
-            .header
-            .height;
-        let last_height = self.indexer.get_last_height().0 + 1;
-        // let check_forks: bool = best_height - last_height < 1000;
-        info!("Initiating index from {} to {}", last_height, best_height);
-        let heights = last_height..=best_height.0;
-
-        tokio_stream::iter(heights)
-            .map(|height| {
-                let block_provider = Arc::clone(&self.block_provider);
-                tokio::task::spawn(async move {
-                    block_provider
-                        .get_block_by_height(height.into())
-                        .await
-                        .unwrap()
-                })
-            })
-            .buffered(num_cpus::get())
-            .map(|res| match res {
-                Ok(block) => block,
-                Err(e) => panic!("Error: {:?}", e),
-            })
-            .min_batch_with_weight(min_batch_size, |block| block.txs.len())
-            .map(|(blocks, tx_count)| {
-                let block_provider = Arc::clone(&self.block_provider);
-                tokio::task::spawn_blocking(move || block_provider.process_batch(&blocks, tx_count))
-            })
-            .buffered(num_cpus::get())
-            .map(|res| match res {
-                Ok((block_batch, tx_count)) => {
-                    let chain_link = block_batch
-                        .last()
-                        .is_some_and(|b| best_height.0 < b.header.height.0 + 1000);
-                    self.monitor.monitor(&block_batch, &tx_count);
-                    self.indexer
-                        .persist_blocks(block_batch, chain_link)
-                        .unwrap_or_else(|e| panic!("Unable to persist blocks due to {}", e))
-                }
-                Err(e) => panic!("Unable to process blocks: {:?}", e),
+            .map(|(block_batch, tx_count)| {
+                let chain_link = block_batch.last().is_some_and(|_| is_chain_tip);
+                self.monitor.monitor(&block_batch, &tx_count);
+                self.indexer
+                    .persist_blocks(block_batch, chain_link)
+                    .unwrap_or_else(|e| panic!("Unable to persist blocks due to {}", e))
             })
             .count()
             .await;
@@ -107,8 +67,8 @@ impl<'db, CF: CustomFamilies<'db>, InTx: Send + 'static, OutTx: Transaction + Se
     }
 }
 
-impl<'db, CF: CustomFamilies<'db>, InTx: Send + 'static, OutTx: Transaction + Send + 'static> Drop
-    for ChainSyncer<'db, CF, InTx, OutTx>
+impl<'db, CF: CustomFamilies<'db>, OutTx: Transaction + Send + 'static> Drop
+    for ChainSyncer<'db, CF, OutTx>
 {
     fn drop(&mut self) {
         info!("Dropping indexer");

--- a/todo
+++ b/todo
@@ -1,2 +1,14 @@
-chain-link only at the tip 
-keep only utxo service in utxo, TxService should be generic as we don't want to reimplement it for account-based chains
+
+nohup cardano-node run \
+--config /opt/cardano-node/config.json \
+--database-path /opt/cardano-node/db/ \
+--socket-path /opt/cardano-node/db/node.socket \
+--host-addr 0.0.0.0 \
+--port 1337 \
+--topology /opt/cardano-node/topology.json &
+
+
+Syncing : 
+    - Sources
+        - Btc - (hash, height, timestamp) from database
+        - Cardano - (hash, height, slot) from database


### PR DESCRIPTION
Cardano has the same utxo model as Bitcoin so it is compatible ... 

Trying to add Ergo however it is different. Instead of `tx.inputs[0] { tx_hash, tx_output_index }` as Bitcoin or Cardano, it has `tx.inputs[0] { box_id, spending_proof }` ... so we would need to build an extra `box_id -> (tx_hash, tx_output_index)` lookup table ...