### PR TITLE
revert assets refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PK           = unique pointer to an object
 BirthPK      = unique pointer to an object of creation
 Hash         = Hash of an object
 Index        = Secondary Index
-Asset Action = Mint, Transfer, Burn
+Asset Action = Mint / Transfer
 ```
 ```
 HeightPk     = block_height
@@ -112,11 +112,18 @@ UtxoBirthPk_with_UtxoPk_relations:
 
 ### Assets
 
-Assets are for now just basic with single one-to-many secondary index 
+Assets are for now just basic with single one-to-many secondary index with spent/unspent info
 
 ```
 AssetValueAndBirthPk_by_UtxoPk:
-    asset_pk -> asset_value|asset_birth_pk|action
+    utxo_pk -> [asset_value|action|asset_birth_pk]
+
+Spent_UtxoAssetPk_by_InputAssetPk:
+    input_asset_pk -> utxo_asset_pk
+
+Spent_InputAssetPk_by_UtxoAssetPk:
+    utxo_asset_pk -> input_asset_pk
+
 ```
 
 ### Asset index

--- a/src/eutxo/eutxo_codec_utxo.rs
+++ b/src/eutxo/eutxo_codec_utxo.rs
@@ -27,6 +27,27 @@ struct EutxoPk {
     pub utxo_index: UtxoIndex,
 }
 
+pub fn get_asset_value_ation_birth_pks(
+    asset_value_birth_pk_bytes: &[u8],
+) -> Vec<(AssetValue, AssetAction, AssetBirthPkBytes)> {
+    let asset_value_action_pk_size = 18;
+    let asset_count = asset_value_birth_pk_bytes.len() / asset_value_action_pk_size;
+    let mut result = Vec::with_capacity(asset_count);
+
+    for chunk in asset_value_birth_pk_bytes.chunks_exact(asset_value_action_pk_size) {
+        let asset_value = BigEndian::read_u64(&chunk[0..8]);
+
+        let asset_action: AssetAction = AssetAction::try_from(chunk[8]).unwrap();
+
+        let mut asset_birth_pk_bytes = [0u8; 9];
+        asset_birth_pk_bytes.copy_from_slice(&chunk[9..18]);
+
+        result.push((asset_value, asset_action, asset_birth_pk_bytes));
+    }
+
+    result
+}
+
 pub fn get_asset_value_birth_pk_action(
     asset_value_birth_pk_action_bytes: &[u8],
 ) -> (AssetValue, AssetBirthPkBytes, AssetAction) {

--- a/src/eutxo/eutxo_codec_utxo.rs
+++ b/src/eutxo/eutxo_codec_utxo.rs
@@ -18,7 +18,7 @@ pub type UtxoBirthPkBytes = UtxoPkBytes;
 
 pub type AssetPkBytes = [u8; 9];
 pub type AssetBirthPkBytes = AssetPkBytes;
-pub type AssetValueWithIndex = Vec<u8>;
+pub type AssetValueActionBirthPk = Vec<u8>;
 
 #[derive(Debug, PartialEq, Clone)]
 struct EutxoPk {

--- a/src/eutxo/eutxo_executor.rs
+++ b/src/eutxo/eutxo_executor.rs
@@ -80,7 +80,7 @@ pub async fn run_eutxo_indexing(
                     (*index_number, db.cf_handle(index_name).unwrap())
                 })
                 .collect::<HashMap<DbIndexNumber, Arc<BoundColumnFamily>>>(),
-            asset_by_asset_pk_cf: db.cf_handle(ASSET_BY_ASSET_PK_CF).unwrap(),
+            assets_by_utxo_pk_cf: db.cf_handle(ASSET_BY_ASSET_PK_CF).unwrap(),
             asset_id_by_asset_birth_pk_cf: db.cf_handle(ASSET_ID_BY_ASSET_BIRTH_PK_CF).unwrap(),
             asset_birth_pk_by_asset_id_cf: db.cf_handle(ASSET_BIRTH_PK_BY_ASSET_ID_CF).unwrap(),
             asset_birth_pk_with_asset_pk_cf: db.cf_handle(ASSET_BIRTH_PK_WITH_ASSET_PK_CF).unwrap(),

--- a/src/eutxo/eutxo_families.rs
+++ b/src/eutxo/eutxo_families.rs
@@ -15,7 +15,7 @@ pub struct EutxoFamilies<'db> {
     pub o2m_utxo_birth_pk_by_index_cf: HashMap<DbIndexNumber, Arc<BoundColumnFamily<'db>>>,
     pub o2m_index_by_utxo_birth_pk_cf: HashMap<DbIndexNumber, Arc<BoundColumnFamily<'db>>>,
     pub o2o_utxo_birth_pk_by_index_cf: HashMap<DbIndexNumber, Arc<BoundColumnFamily<'db>>>,
-    pub asset_by_asset_pk_cf: Arc<BoundColumnFamily<'db>>,
+    pub assets_by_utxo_pk_cf: Arc<BoundColumnFamily<'db>>,
     pub asset_id_by_asset_birth_pk_cf: Arc<BoundColumnFamily<'db>>,
     pub asset_birth_pk_by_asset_id_cf: Arc<BoundColumnFamily<'db>>,
     pub asset_birth_pk_with_asset_pk_cf: Arc<BoundColumnFamily<'db>>,
@@ -27,7 +27,7 @@ impl<'db> CustomFamilies<'db> for EutxoFamilies<'db> {
         all.push(Arc::clone(&self.utxo_value_by_pk_cf));
         all.push(Arc::clone(&self.utxo_pk_by_input_pk_cf));
         all.push(Arc::clone(&self.input_pk_by_utxo_pk_cf));
-        all.push(Arc::clone(&self.asset_by_asset_pk_cf));
+        all.push(Arc::clone(&self.assets_by_utxo_pk_cf));
         all.push(Arc::clone(&self.asset_id_by_asset_birth_pk_cf));
         all.push(Arc::clone(&self.asset_birth_pk_by_asset_id_cf));
         all.push(Arc::clone(&self.asset_birth_pk_with_asset_pk_cf));

--- a/todo
+++ b/todo
@@ -2,6 +2,3 @@ ergo - registers
 cardano - datum
 
 assets - spent/unspent
-
-
-!! Families and DbSchema should be united !!


### PR DESCRIPTION
It turned out to be 2x slow so we decreased from 3000tx/s for cardano and ergo to 1500tx/s as there a lot of assets.